### PR TITLE
Add '0' when minutes are under 10 to fix error.

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -8,6 +8,7 @@ const setDefaultTime = () => {
     let currentTime = new Date(Date.now()),
     currentHours = currentTime.getHours(),
     currentMinutes = currentTime.getMinutes();
+    currentMinutes = currentMinutes < 10 ? `0${currentMinutes}` : currentMinutes;
 
     $("#time-selector").val(`${currentHours}:${currentMinutes}`);
 };


### PR DESCRIPTION
This should be merged because it is required for the hour selector to work.